### PR TITLE
Check if target is dismiss or trigger in FileUpload data-api click handler

### DIFF
--- a/js/bootstrap-fileupload.js
+++ b/js/bootstrap-fileupload.js
@@ -132,7 +132,8 @@
       if ($this.data('fileupload')) return
       $this.fileupload($this.data())
       
-      var $target = $(e.target).parents('[data-dismiss=fileupload],[data-trigger=fileupload]').first()
+      var $target = $(e.target).is('[data-dismiss=fileupload],[data-trigger=fileupload]') ?
+        $(e.target) : $(e.target).parents('[data-dismiss=fileupload],[data-trigger=fileupload]').first()
       if ($target.length > 0) {
           $target.trigger('click.fileupload')
           e.preventDefault()


### PR DESCRIPTION
Currently, if you use a fileupload that starts out as 'existing' and you click the clear button first, nothing happens. This happens because the data-api callback only checks the parents of e.target for the data-dismiss and data-trigger attributes. This patch first checks if e.target itself has a data-dismiss or data-trigger attribute.
