### PR TITLE
Added variable Iconic font path.

### DIFF
--- a/less/iconic.less
+++ b/less/iconic.less
@@ -5,14 +5,14 @@
 @font-face {
   font-family: IconicStroke;
   font-weight: normal;
-  src: url('../fonts/iconic_stroke.eot');
-  src: local('IconicStroke'), url('iconic_stroke.eot?#iefix') format('../fonts/embedded-opentype'), url('../fonts/iconic_stroke.woff') format('woff'), url('../fonts/iconic_stroke.ttf') format('truetype'), url('iconic_stroke.svg#iconic') format('svg'), url('../fonts/iconic_stroke.otf') format('opentype');
+  src: url(~'@{iconicFontPath}/iconic_stroke.eot');
+  src: local('IconicStroke'), url('iconic_stroke.eot?#iefix') format(~'@{iconicFontPath}/embedded-opentype'), url(~'@{iconicFontPath}/iconic_stroke.woff') format('woff'), url(~'@{iconicFontPath}/iconic_stroke.ttf') format('truetype'), url('iconic_stroke.svg#iconic') format('svg'), url(~'@{iconicFontPath}/iconic_stroke.otf') format('opentype');
 }
 @font-face {
   font-family: IconicFill;
   font-weight: normal;
-  src: url('../fonts/iconic_fill.eot');
-  src: local('IconicFill'), url('../fonts/iconic_fill.eot?#iefix') format('embedded-opentype'), url('../fonts/iconic_fill.woff') format('woff'), url('../fonts/iconic_fill.ttf') format('truetype'), url('iconic_fill.svg#iconic') format('svg'), url('../fonts/iconic_fill.otf') format('opentype');
+  src: url(~'@{iconicFontPath}/iconic_fill.eot');
+  src: local('IconicFill'), url(~'@{iconicFontPath}/iconic_fill.eot?#iefix') format('embedded-opentype'), url(~'@{iconicFontPath}/iconic_fill.woff') format('woff'), url(~'@{iconicFontPath}/iconic_fill.ttf') format('truetype'), url('iconic_fill.svg#iconic') format('svg'), url(~'@{iconicFontPath}/iconic_fill.otf') format('opentype');
 }
 
 // Icons

--- a/less/variables.less
+++ b/less/variables.less
@@ -153,6 +153,7 @@
 // -------------------------
 @iconSpritePath:          "../img/glyphicons-halflings.png";
 @iconWhiteSpritePath:     "../img/glyphicons-halflings-white.png";
+@iconicFontPath:          "../font";
 
 
 // Input placeholder text color


### PR DESCRIPTION
Using the Less compiler to combine and minify Less files will break Iconic icons because the paths to the fonts won't be correct anymore. The default path, which is relative to `/public/bootstrap/iconic.less`, won't work for, say, `/public/path/to/my/file.less`. (note that this doesn't happen with less.js).

A variable `@iconicFontPath` that defaults to the current font files location preserves the current functionality and will allow developers to override this in their own custom `variables.less` with an absolute path, if necessary.
