### PR TITLE
fix js rowlink docu (nohref -> nolink)

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1522,8 +1522,8 @@ $('.carousel').carousel({
         </div>
         <pre class="prettyprint linenums">
 &lt;table data-provides="rowlink"&gt;
-  &lt;tr&gt;&lt;td&gt;&lt;a href="javascript.html#modals"&gt;Modals&lt;/a&gt;&lt;/td&gt;&lt;td class="nohref"&gt;&lt;a href="#"&gt;Action&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
-  &lt;tr&gt;&lt;td&gt;&lt;a href="javascript.html#dropdowns"&gt;Dropdowns&lt;/a&gt;&lt;/td&gt;&lt;td class="nohref"&gt;&lt;a href="#"&gt;Action&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
+  &lt;tr&gt;&lt;td&gt;&lt;a href="javascript.html#modals"&gt;Modals&lt;/a&gt;&lt;/td&gt;&lt;td class="nolink"&gt;&lt;a href="#"&gt;Action&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
+  &lt;tr&gt;&lt;td&gt;&lt;a href="javascript.html#dropdowns"&gt;Dropdowns&lt;/a&gt;&lt;/td&gt;&lt;td class="nolink"&gt;&lt;a href="#"&gt;Action&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
 &lt;/table&gt;
         </pre>
 


### PR DESCRIPTION
rowlink example read: td class="nohref"
changed to td class="nolink"
