### PR TITLE
Update js/bootstrap-fileupload.js

### DIFF
--- a/js/bootstrap-fileupload.js
+++ b/js/bootstrap-fileupload.js
@@ -100,7 +100,7 @@
       this.$input.attr('name', '')
 
       //ie8+ doesn't support changing the value of input with type=file so clone instead
-      if($.browser.msie){
+      if (navigator.userAgent.match(/msie/i)){ 
           var inputClone = this.$input.clone(true);
           this.$input.after(inputClone);
           this.$input.remove();


### PR DESCRIPTION
This addresses Issue #55, #62
https://github.com/jasny/bootstrap/issues/55
https://github.com/jasny/bootstrap/issues/62

Support for jquery.browser was removed in 1.9. This caused the "Remove" button to not work. 

Changed line 103 from 
   if($.browser.msie){
to 
   if (navigator.userAgent.match(/msie/i)){
