### PR TITLE
Add <a> to all <td>s

### DIFF
--- a/js/bootstrap-rowlink.js
+++ b/js/bootstrap-rowlink.js
@@ -31,9 +31,15 @@
       
       var href = link.attr('href')
 
-      $(this).find('td').not('.nolink').click(function() {
-        window.location = href;
+      $(this).find('td').not('.nolink').each(function() {
+        var a = $("<a href=\"" + href + "\" class=\"rowlink\">");
+        $(this).children(":not(div, table, form)").appendTo(a);
+        a.appendTo($(this));
       })
+      
+      $(this).click(function() {
+        location.href=href;
+      });
 
       $(this).addClass('rowlink')
       link.replaceWith(link.html())


### PR DESCRIPTION
It's great to be able to right-click and select "Copy link location" etc, properties of normal link elements. However, a is invalid around div, table, and form so that's left out.
