### PR TITLE
Add Max-width attributes to the filename

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -48,6 +48,9 @@
       hiddenVal: this.$hidden.val()
     }
     
+    this.$element.find('.fileinput-filename').css("max-width", (this.$element.find('[data-trigger="fileinput"]').width()-50)+"px");
+  
+    
     this.listen()
   }
   


### PR DESCRIPTION
This is to prevent the filename to be larger than the parent. I will add a few lines of CSS too.
