### PR TITLE
Speed up presentation of file preview

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -75,7 +75,8 @@
       var element = this.$element
 
       reader.onload = function(re) {
-        var $img = $('<img>').attr('src', re.target.result)
+        var $img = $('<img>') // .attr('src', re.target.result)
+        $img[0].src = re.target.result
         e.target.files[0].result = re.target.result
         
         element.find('.fileinput-filename').text(file.name)


### PR DESCRIPTION
I observed that showing preview for a large image in Fileinput may take a long time, especially if file is over few hundred kilobytes (not uncommon)

Turns out to fix it it was enough to remove jQuery assignment and use native javascript one.

I _did not_ test it across browsers, but I am pretty confident it should work everywhere.
