### PR TITLE
Fixed fileinput.less to better support Bootstrap3

### DIFF
--- a/less/fileinput.less
+++ b/less/fileinput.less
@@ -15,6 +15,7 @@
     filter: alpha(opacity=0);
     transform: translate(-300px, 0) scale(4);
     font-size: 23px;
+    height: 100%;
     direction: ltr;
     cursor: pointer;
   }


### PR DESCRIPTION
I removed references to .uneditable-input as this component no longer exists in bootstrap3. I also modified the contextual styles to match those that exist (.form-group.has-error, etc.) in bootstrap3.

Also, I added support for switching around the order of buttons within the input group (I like to put the remove button in front of the file name).

Additionally, removed the button size styles in favor of using .input-group-lg and .input-group-sm
