### PR TITLE
Fix to naming in inputmask.js and added some inputmask tests

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -32,7 +32,7 @@
     if (isAndroid) return // No support because caret positioning doesn't work on Android
     
     this.$element = $(element)
-    this.options = $.extend({}, Inputmask.DEFAULS, options)
+    this.options = $.extend({}, Inputmask.DEFAULTS, options)
     this.mask = String(this.options.mask)
     
     this.init()
@@ -41,7 +41,7 @@
     this.checkVal() //Perform initial check for existing values
   }
 
-  Inputmask.DEFAULS = {
+  Inputmask.DEFAULTS = {
     mask: "",
     placeholder: "_",
     definitions: {

--- a/js/tests/unit/inputmask.js
+++ b/js/tests/unit/inputmask.js
@@ -1,6 +1,13 @@
 $(function () {
 
-    module('inputmask')
+      var $body;
+
+      module('inputmask', {
+        setup : function() {
+          $body = $(document.body);
+          $body.removeData('inputmask');
+        }
+      })
 
       test('should provide no conflict', function () {
         var inputmask = $.fn.inputmask.noConflict()
@@ -15,6 +22,60 @@ $(function () {
       test('should return element', function () {
         ok($(document.body).inputmask()[0] == document.body, 'document.body returned')
       })
-      
+
+      test('should use default mask', function() {
+        var expected = ""
+        $.fn.inputmask.Constructor.DEFAULTS.mask = expected
+
+        $body.inputmask()
+
+        equal(expected, $body.data('inputmask').options.mask)
+      })
+
+      test('should use default placeholder', function() {
+        var expected = "_"
+        $.fn.inputmask.Constructor.DEFAULTS.placeholder = expected
+
+        $body.inputmask()
+
+        equal(expected, $body.data('inputmask').options.placeholder)
+      })
+
+      test('should use default definitions', function() {
+        var expected = {
+          '9': "[0-9]",
+          'a': "[A-Za-z]"
+        }
+        $.fn.inputmask.Constructor.DEFAULTS.definitions = expected
+
+        $body.inputmask()
+
+        deepEqual(expected, $body.data('inputmask').options.definitions)
+      })
+
+      test('should override mask when options.mask provided', function() {
+        var expected = '99-99';
+        $body.inputmask({ mask: expected})
+
+        equal(expected, $body.data('inputmask').options.mask)
+      })
+
+      test('should override placeholder when options.placeholder provided', function() {
+          var expected = '-';
+          $body.inputmask({ placeholder: expected})
+
+          equal(expected, $body.data('inputmask').options.placeholder)
+      })
+
+      test('should override definitions when options.definitions provided', function() {
+        var expected = {
+          '9': "[0-9]",
+          'a': "[A-Za-z]"
+        }
+
+        $body.inputmask({definitions: expected})
+
+        deepEqual(expected, $body.data('inputmask').options.definitions)
+      })
       // TODO: add inputmask tests
 })


### PR DESCRIPTION
Changed the name of property Inputmask.DEFAULS to Inputmask.DEFAULTS and added unit tests
around how the inputmask options are set up.

Tested in: Firefox 28.0 and Chrome 33.0
