### PR TITLE
Update input mask documentation

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -396,8 +396,8 @@ $('.inputmask').inputmask({
         <tbody>
           <tr><td>9</td><td>Number</td></tr>
           <tr><td>a</td><td>Letter</td></tr>
-          <tr><td>?</td><td>Alphanumeric</td></tr>
-          <tr><td>*</td><td>Any character</td></tr>
+          <tr><td>*</td><td>Alphanumeric</td></tr>
+          <tr><td>?</td><td>Optional - any characters following will become optional</td></tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
The documentation for this is off a little bit - in the list
of characters in the "Format" section, the ? character is
listed as Alphanumeric, however this is incorrect. Instead,
anything proceeding it in the defined mask is deemed optional.
The asterisk \* is then listed as Any character, but this is
actually the alphanumeric denotation, so I swapped them.
