### PR TITLE
.navmenu height fix

### DIFF
--- a/less/navmenu.less
+++ b/less/navmenu.less
@@ -10,7 +10,7 @@
 .navmenu,
 .navbar-offcanvas {
   width: @navmenu-width;
-  height: 100%;
+  height: auto;
   border-width: 1px;
   border-style: solid;
   border-radius: @border-radius-base;


### PR DESCRIPTION
The `.navmenu` height needs to be set to `auto` in order to allow the `top` and `bottom` values to properly work. The `top` value works fine, but the `bottom` value is rendered inert because the `height: 100%` causes the `.navmenu` to overflow down through the viewport.
