### PR TITLE
fix for #252 - input with input maske doesn't get updated

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -209,8 +209,10 @@
 
   Inputmask.prototype.blurEvent = function() {
     this.checkVal()
-    if (this.$element.val() !== this.focusText)
+    if (this.$element.val() !== this.focusText) {
       this.$element.trigger('change')
+      this.$element.trigger('input')
+    }
   }
 
   Inputmask.prototype.keydownEvent = function(e) {


### PR DESCRIPTION
added `input` event to support bootstrapvalidator.
Working demo: http://jsfiddle.net/Misiu/b6cwC/1/
