### PR TITLE
Allow touching in the offcanvas area

### DIFF
--- a/js/offcanvas.js
+++ b/js/offcanvas.js
@@ -156,7 +156,8 @@
     }
     //disable scrolling on mobiles (they ignore overflow:hidden)
     $('body').on('touchmove.bs', function(e) {
-      e.preventDefault();
+      if (!$(event.target).closest('.offcanvas').length)
+        e.preventDefault();
     });
   }
 


### PR DESCRIPTION
Preventing touch on the entire body prevents offcanvas navmenu from scrolling in some cases. This fixes those instances. iPhone 5C exhibits this issue with non-fixed navbar offcanvas example.

http://jasny.github.io/bootstrap/examples/navbar-offcanvas/
