### PR TITLE
Navmenu on the right with scrollbar

### DIFF
--- a/scss/_navmenu.scss
+++ b/scss/_navmenu.scss
@@ -23,6 +23,7 @@
   z-index: $zindex-navmenu-fixed;
   top: 0;
   border-radius: 0;
+  overflow-y: auto;
 }
 .navmenu-fixed-left,
 .navbar-offcanvas.navmenu-fixed-left {
@@ -30,7 +31,6 @@
   right: auto;
   border-width: 0 1px 0 0;
   bottom: 0;
-  overflow-y: auto;
 }
 .navmenu-fixed-right,
 .navbar-offcanvas {


### PR DESCRIPTION
Offcanvas navmenu fixed to the right had no overflow-y, so no scrollbars where shown
