### PR TITLE
Fix jasny/bootstrap#279

### DIFF
--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -8,6 +8,10 @@
   }
 }
 
+.offcanvas {
+  @include offcanvas;
+}
+
 @media (max-width: $screen-xs-max) {
   .offcanvas-xs {
     @include offcanvas;


### PR DESCRIPTION
Sass port turned declaration into mixin, without leaving the declaration. Added the declaration back in.
