### PR TITLE
Fileinput: Close button should not have inline styles

### DIFF
--- a/less/fileinput.less
+++ b/less/fileinput.less
@@ -50,6 +50,12 @@
 .fileinput-new .fileinput-exists {
   display: none;
 }
+
+//close X button alignment
+.fileinput-exists.close {
+  float: none;
+}
+
 .fileinput-inline .fileinput-controls {
   display: inline;
 }
@@ -65,7 +71,7 @@
 
 .fileinput.input-group {
     display: table;
-    
+
     > * {
         position: relative;
         z-index: 2;

--- a/scss/_fileinput.scss
+++ b/scss/_fileinput.scss
@@ -50,6 +50,12 @@
 .fileinput-new .fileinput-exists {
   display: none;
 }
+
+//close X button alignment
+.fileinput-exists.close {
+  float: none;
+}
+
 .fileinput-inline .fileinput-controls {
   display: inline;
 }


### PR DESCRIPTION
This addition to the `.fileinput.close` element makes it
possible to remove inline style as seen in the documentation.

Specifically, I could remove `style="float:none"` based on this change.