### PR TITLE
Fix off-canvas menu fro pushing .navbar content when the scrollbar is visible

### DIFF
--- a/js/offcanvas.js
+++ b/js/offcanvas.js
@@ -145,7 +145,10 @@
       $('body').data('offcanvas-style', $('body').attr('style') || '')
     }
       
-    $('body').css('overflow', 'hidden')
+    $('body').css({ 
+      overflowY: 'scroll',
+      position: 'fixed'
+    });
 
     if ($('body').width() > bodyWidth) {
       var padding = parseInt($('body').css(prop), 10) + $('body').width() - bodyWidth


### PR DESCRIPTION
The off-canvas menu pushes the `.navbar` content when you have a vertical scrollbar.

You can view the bug on the [off-canvas documentation](http://jasny.github.io/bootstrap/examples/navmenu/). Just resize your browser so there's a vertical scrollbar. Open the menu and you'll see that the page content gets pushed.

This fix makes it so that the page width stays the same (and doesn't get pushed), while maintaining that scrolling is disabled.
