### PR TITLE
Fix grunt test breakage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -276,7 +276,9 @@ module.exports = function (grunt) {
         reset: true,
         relaxerror: [
           'Bad value X-UA-Compatible for attribute http-equiv on element meta.',
-          'Element img is missing required attribute src.'
+          'Element img is missing required attribute src.',
+          'This interface to HTML5 document checking is deprecated.',
+          '\\& did not start a character reference. \\(\\& probably should have been escaped as \\&amp;.\\)'
         ]
       },
       files: {

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -376,7 +376,6 @@ span.hidden-sm {
   background: rgba(255, 255, 255, 0.15) !important;
   box-shadow: inset 0 3px 5px rgba(0,0,0,.075);
   border: 0 !important;
-  box-shadow: inset 0 3px 5px rgba(0,0,0,.075);
 }
 .carbon-img {
   margin: 0 !important;


### PR DESCRIPTION
Currently, ``grunt test`` does not run successfully so build is marked as failing. Two reasons for failing build are addressed in this PR

 * repeated style in docs.css
 * w3 validation service deprecation notice and aggressive handling of ampersands in URL parameters
