### PR TITLE
Modified composer to install as component when using symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,32 @@
 {
-    "name": "jasny/bootstrap"
-  , "description": "The missing bootstrap components"
-  , "keywords": ["bootstrap", "css"]
-  , "homepage": "http://jasny.github.io/bootstrap"
-  , "authors": [
+    "name": "jasny/bootstrap",
+    "description": "The missing bootstrap components",
+    "type": "component",
+    "keywords": ["bootstrap", "css"],
+    "homepage": "http://jasny.github.io/bootstrap",
+    "authors": [
       {
         "name": "Arnold Daniels",
         "email": "arnold@jasny.net"
       }
-    ]
-  , "support": {
+    ],
+    "support": {
       "issues": "https://github.com/jasny/bootstrap/issues"
-    }
-  , "license": "Apache-2.0"
-  , "require": {
+    },
+    "license": "Apache-2.0",
+    "require": {
       "twbs/bootstrap" : ">=3.1.0"
+    },
+    "extra": {
+      "component": {
+        "scripts": [
+          "dist/js/jasny-bootstrap.js",
+          "dist/js/jasny-bootstrap.min.js"
+        ],
+        "styles": [
+          "dist/css/jasny-bootstrap.css",
+          "dist/css/jasny-bootstrap.min.css"
+        ]
+      }
     }
 }


### PR DESCRIPTION
When installing via composer in many frameworks it does not install in th property folder.
Adding this lines to the composer file allow installer to know wich files have to made public and copy to the "symfony-web-dir" composer parameter (in the case of symfony).