### PR TITLE
Update jasny-bootstrap.css

### DIFF
--- a/dist/css/jasny-bootstrap.css
+++ b/dist/css/jasny-bootstrap.css
@@ -574,6 +574,12 @@
   display: inline-block;
   overflow: hidden;
   vertical-align: middle;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  padding-left: 30px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .form-control .fileinput-filename {
   vertical-align: bottom;


### PR DESCRIPTION
Update the .fileinput-filename class to fix long text strings ovefow

![79df5f3e-71ac-11e4-9692-c3268941a398](https://cloud.githubusercontent.com/assets/580591/13103999/c2c4aa70-d55a-11e5-8633-39a2acbabaab.png)