### PR TITLE
Update package.json to fix main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jasny-bootstrap",
   "description": "Additional features and components for Bootstrap",
   "version": "3.1.3",
-  "main": "dist/jasny-bootstrap.js",
+  "main": "dist/js/jasny-bootstrap.js",
   "keywords": [
     "bootstrap",
     "css"


### PR DESCRIPTION
The  path for main is incorrect which causes webpack to fail if you install jasny-bootstrap with npm from github. Quick fix to point at dist/js/jasny-bootstrap.js instead of dist/jasny-bootstrap.js