### PR TITLE
Fixed issues #263

### DIFF
--- a/less/fileinput.less
+++ b/less/fileinput.less
@@ -61,9 +61,15 @@
 }
 
 .fileinput-filename {
-  vertical-align: middle;
   display: inline-block;
   overflow: hidden;
+  vertical-align: middle;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  padding-left: 30px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .form-control .fileinput-filename {
   vertical-align: bottom;

--- a/scss/_fileinput.scss
+++ b/scss/_fileinput.scss
@@ -61,11 +61,17 @@
 }
 
 .fileinput-filename {
-  vertical-align: middle;
   display: inline-block;
   overflow: hidden;
+  vertical-align: middle;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  padding-left: 30px;
   white-space: nowrap;
   text-overflow: ellipsis;
+
+
 }
 .form-control .fileinput-filename {
   vertical-align: bottom;

--- a/scss/build/_mixins.scss
+++ b/scss/build/_mixins.scss
@@ -1,0 +1,39 @@
+// Mixins
+// --------------------------------------------------
+
+
+// Vendor Prefixes
+//
+// All vendor mixins are deprecated as of v3.2.0 due to the introduction of
+// Autoprefixer in our Gruntfile. They have been removed in v4.
+
+// Drop shadows
+//
+// Note: Deprecated `.box-shadow()` as of v3.1.0 since all of Bootstrap's
+// supported browsers that have box shadow capabilities now support it.
+
+@mixin box-shadow($shadow...) {
+  -webkit-box-shadow: $shadow; // iOS <4.3 & Android <4.1
+          box-shadow: $shadow;
+}
+
+
+// Single side border-radius
+
+@mixin border-top-radius($radius) {
+  border-top-right-radius: $radius;
+   border-top-left-radius: $radius;
+}
+@mixin border-right-radius($radius) {
+  border-bottom-right-radius: $radius;
+     border-top-right-radius: $radius;
+}
+@mixin border-bottom-radius($radius) {
+  border-bottom-right-radius: $radius;
+   border-bottom-left-radius: $radius;
+}
+@mixin border-left-radius($radius) {
+  border-bottom-left-radius: $radius;
+     border-top-left-radius: $radius;
+}
+

--- a/scss/build/_variables.scss
+++ b/scss/build/_variables.scss
@@ -1,0 +1,142 @@
+//
+// These variables are used when Jasny Bootstrap is built
+// without importing vanilla Bootstrap.
+// --------------------------------------------------------
+//== Colors
+//
+//## Gray and brand colors for use across Bootstrap.
+
+$gray-base:              #000 !default;
+$gray-light:             lighten($gray-base, 46.7%) !default; // #777
+
+//== Typography
+//
+//## Font, line-height, and color for body text, headings, and more.
+
+$font-size-base:          14px !default;
+$font-size-large:         ceil(($font-size-base * 1.25)) !default; // ~18px
+//** Unit-less `line-height` for use in components like buttons.
+$line-height-base:        1.428571429 !default; // 20/14
+//** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
+$line-height-computed:    floor(($font-size-base * $line-height-base)) !default; // ~20px
+
+//== Components
+//
+//## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
+
+$padding-base-vertical:     6px !default;
+$padding-base-horizontal:   12px !default;
+
+$padding-large-vertical:    10px !default;
+$padding-large-horizontal:  16px !default;
+
+$padding-small-vertical:    5px !default;
+$padding-small-horizontal:  10px !default;
+
+$border-radius-base:        4px !default;
+$border-radius-large:       6px !default;
+$border-radius-small:       3px !default;
+
+//== Tables
+//
+//## Customizes the `.table` component with basic values, each used across all table variations.
+
+//** Background color used for `.table-hover`.
+$table-bg-hover:                #f5f5f5 !default;
+
+//== Media queries breakpoints
+//
+//## Define the breakpoints at which your layout will change, adapting to different screen sizes.
+
+// Extra small screen / phone
+//** Deprecated `$screen-xs` as of v3.0.1
+$screen-xs:                  480px !default;
+//** Deprecated `$screen-xs-min` as of v3.2.0
+$screen-xs-min:              $screen-xs !default;
+//** Deprecated `$screen-phone` as of v3.0.1
+$screen-phone:               $screen-xs-min !default;
+
+// Small screen / tablet
+//** Deprecated `$screen-sm` as of v3.0.1
+$screen-sm:                  768px !default;
+$screen-sm-min:              $screen-sm !default;
+
+// Medium screen / desktop
+//** Deprecated `$screen-md` as of v3.0.1
+$screen-md:                  992px !default;
+$screen-md-min:              $screen-md !default;
+
+// Large screen / wide desktop
+//** Deprecated `$screen-lg` as of v3.0.1
+$screen-lg:                  1200px !default;
+$screen-lg-min:              $screen-lg !default; 
+
+// // So media queries don't overlap when required, provide a maximum
+$screen-xs-max:              ($screen-sm-min - 1) !default;
+$screen-sm-max:              ($screen-md-min - 1) !default;
+$screen-md-max:              ($screen-lg-min - 1) !default;
+
+
+//== Grid system
+//
+//## Define your custom responsive grid.
+
+//** Padding between columns. Gets divided in half for the left and right.
+$grid-gutter-width:         30px !default;
+// Navbar collapse
+//** Point at which the navbar becomes uncollapsed.
+$grid-float-breakpoint:     $screen-sm-min !default;
+
+
+//== Container sizes
+//
+//## Define the maximum width of `.container` for different screen sizes.
+
+// Large screen / wide desktop
+$container-large-desktop:      (1140px + $grid-gutter-width) !default;
+//** For `$screen-lg-min` and up.
+$container-lg:                 $container-large-desktop !default;
+
+
+//== Navbar
+//
+//##
+
+// Basics of a navbar
+$navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;
+
+//== Navs
+//
+//##
+
+//=== Shared nav styles
+$nav-link-padding:                          10px 15px !default;
+
+$nav-disabled-link-color:                   $gray-light !default;
+$nav-disabled-link-hover-color:             $gray-light !default;
+
+//== Tabs
+$nav-tabs-border-color:                     #ddd !default;
+$nav-tabs-active-link-hover-border-color:   #ddd !default;
+
+//== Form states and alerts
+//
+//## Define colors for form feedback states and, by default, alerts.
+
+$state-success-text:             #3c763d !default;
+$state-success-bg:               #dff0d8 !default;
+$state-success-border:           darken(adjust-hue($state-success-bg, -10), 5%) !default;
+
+$state-warning-text:             #8a6d3b !default;
+$state-warning-bg:               #fcf8e3 !default;
+$state-warning-border:           darken(adjust-hue($state-warning-bg, -10), 5%) !default;
+// 
+$state-danger-text:              #a94442 !default;
+$state-danger-bg:                #f2dede !default;
+$state-danger-border:            darken(adjust-hue($state-danger-bg, -10), 5%) !default;
+
+//== Alerts
+//
+//## Define alert colors, border radius, and padding.
+
+$alert-border-radius:         $border-radius-base !default;

--- a/scss/build/jasny-bootstrap.scss
+++ b/scss/build/jasny-bootstrap.scss
@@ -1,0 +1,5 @@
+// Jasny Bootstrap with default variables
+
+@import "variables";
+@import "mixins";
+@import "../jasny-bootstrap";

--- a/scss/jasny-bootstrap.scss
+++ b/scss/jasny-bootstrap.scss
@@ -1,4 +1,10 @@
 // Vanilla Bootstrap's "variables.scss" should already be imported
+/*!
+ * Jasny Bootstrap v3.1.3 (http://jasny.github.io/bootstrap)
+ * Copyright 2012-2015 Arnold Daniels
+ * Licensed under Apache-2.0 (https://github.com/jasny/bootstrap/blob/master/LICENSE)
+ * 
+ */
 
 // Core variables
 @import "variables";


### PR DESCRIPTION
Create sass compile without bootstrap. 

Fixed issue #263 :
.fileinput-filename {
  display: inline-block;
  overflow: hidden;
  vertical-align: middle;
  width: 100%;
  position: absolute;
  left: 0;
  padding-left: 30px;
  white-space: nowrap;
  text-overflow: ellipsis;
}
