### PR TITLE
Fix for setting menu width. Use bootstrap 3.3.7 (fixes #278)

### DIFF
--- a/docs/examples/navbar-offcanvas/index.html
+++ b/docs/examples/navbar-offcanvas/index.html
@@ -11,7 +11,7 @@
     <title>Navbar Template for Bootstrap</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="//netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
     <link href="../../dist/css/jasny-bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
@@ -81,7 +81,7 @@
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <script src="../../dist/js/jasny-bootstrap.min.js"></script>
   </body>
 </html>

--- a/js/offcanvas.js
+++ b/js/offcanvas.js
@@ -259,6 +259,7 @@
         $(this).attr('style', $(this).data('offcanvas-style')).removeData('offcanvas-style')
       })
 
+      this.$element.css('width', '')
       this.$element.trigger('hidden.bs.offcanvas')
     }
 


### PR DESCRIPTION
As menu is right positioned here by default, we still have problem of it appearing instantly, without sliding (issue https://github.com/jasny/bootstrap/issues/253)