### PR TITLE
data-disable-scrolling="true" not working on iPhone

### DIFF
--- a/js/offcanvas.js
+++ b/js/offcanvas.js
@@ -21,7 +21,7 @@
 
   // OFFCANVAS PUBLIC CLASS DEFINITION
   // =================================
-
+  var isIphone = (navigator.userAgent.match(/iPhone/i)) || (navigator.userAgent.match(/iPod/i))
   var OffCanvas = function (element, options) {
     this.$element = $(element)
     this.options  = $.extend({}, OffCanvas.DEFAULTS, options)
@@ -163,6 +163,10 @@
     }
 
     $('body').css('overflow', 'hidden')
+    //Fix iPhone scrolling
+    if (isIphone) {
+      $('body').addClass('lockIphone');
+    }
 
     if ($('body').width() > bodyWidth) {
       var padding = parseInt($('body').css(prop), 10) + $('body').width() - bodyWidth
@@ -180,6 +184,7 @@
 
   OffCanvas.prototype.enableScrolling = function() {
     $('body').off('touchmove.bs');
+    $('body').removeClass('lockIphone');
   }
 
   OffCanvas.prototype.show = function () {
@@ -208,7 +213,7 @@
     elements.addClass('canvas-sliding').each(function() {
       var $this = $(this)
       if ($this.data('offcanvas-style') === undefined) $this.data('offcanvas-style', $this.attr('style') || '')
-      if ($this.css('position') === 'static') $this.css('position', 'relative')
+      if ($this.css('position') === 'static' && !isIphone) $this.css('position', 'relative')
       if (($this.css(placement) === 'auto' || $this.css(placement) === '0px') &&
           ($this.css(opposite) === 'auto' || $this.css(opposite) === '0px')) {
         $this.css(placement, 0)

--- a/less/navmenu.less
+++ b/less/navmenu.less
@@ -15,7 +15,13 @@
   border-style: solid;
   border-radius: @border-radius-base;
 }
-
+// Fixed iphone with disableScrolling
+.lockIphone {
+  position: fixed;
+  overflow:hidden;
+  height:100%;
+  -webkit-overflow-scrolling: auto;
+}
 // Fix the bug for bootstrap 3.2.0 (https://github.com/jasny/bootstrap/issues/355)
 .navbar-fixed-top,
 .navbar-fixed-bottom {

--- a/less/navmenu.less
+++ b/less/navmenu.less
@@ -18,8 +18,8 @@
 // Fixed iphone with disableScrolling
 .lockIphone {
   position: fixed;
-  overflow:hidden;
-  height:100%;
+  overflow: hidden;
+  height: 100%;
   -webkit-overflow-scrolling: auto;
 }
 // Fix the bug for bootstrap 3.2.0 (https://github.com/jasny/bootstrap/issues/355)


### PR DESCRIPTION
Please make shure if this solution are accepteble.
Problem with scroll whole body on iPhone:
Was: https://www.youtube.com/watch?v=uWtQjul_0KY
Now: https://www.youtube.com/watch?v=UgGW72Rugrg

When user scroll to some lower text, then click on menu - main text are scrolls to top. 
I do not saw any another version to change this. I try create some "clone" div for this navbar, some fake background divisions for navbar. 

This scroll to top will be only for iPhones and iPads. 