### PR TITLE
Fix #362: Offcanvas push can be very slow

### DIFF
--- a/js/offcanvas.js
+++ b/js/offcanvas.js
@@ -124,7 +124,7 @@
     var canvas = this.options.canvas ? $(this.options.canvas) : this.$element
 
     var fixed_elements = canvas.find('*').filter(function() {
-      return $(this).css('position') === 'fixed'
+      return getComputedStyle(this).getPropertyValue('position') === 'fixed'
     }).not(this.options.exclude)
 
     return canvas.add(fixed_elements)


### PR DESCRIPTION
Changed jQuery 
`   $(this).css('position') === 'fixed'`
to native code:
`getComputedStyle(this).getPropertyValue('position') === 'fixed'`

Changed speed from 1.600s to 0.400s. 