### PR TITLE
Fix #345:  Input file validation using Jasny v3.1.3 and jQuery Validator v1.13.1

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -165,7 +165,7 @@
   },
 
   Fileinput.prototype.trigger = function(e) {
-    this.$input.trigger('click')
+    this.$input.focus().trigger('click')
     e.preventDefault()
   }
 


### PR DESCRIPTION
Problem was what in the click trigger was need just do focus on this input. 
I add simple `.focus()` to the trigger `click` on name. 